### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2020-04-19
+### Added
+- Device discovery now also provides model name of each found device.
+- Added the possibility to provide the volume for setVolume command as payload of type 'number'.
+
+### Changed
+- Direct access to Sony audio control web API now abstracted by device node.
+- Manage connections to Sony audio notification API centrally from device node instead of each receiver node.
+
+### Fixed
+- Fixed error logs during device discovery for non-conform devices using Sony's SSDP search scheme.
+
 ## [1.4.0] - 2019-11-17
 ### Added
 - Device discovery to search for Sony audio devices in the network

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ By providing any of the following attributes in the input message, the correspon
 }
 ```
 
-If _Enable Override_ in the _Topic_ section is activated, the command can alternatively be overridden via the `msg.topic` property. This is useful if you want to provide the command via an inject node without using a change node (because the inject node can only set `msg.topic`and `msg.payload`).
+If _Enable Override_ in the _Topic_ section is activated, the command can alternatively be overridden via the `msg.topic` property. This is useful if you want to provide the command via an inject node without using a change node (because the inject node can only set `msg.topic` and `msg.payload`).
 
 Only certain combinations are meaningful, see the following table.
 
@@ -166,7 +166,9 @@ Only certain combinations are meaningful, see the following table.
 |scanBackward| | | | |X|
 |scanForward| | | | |X|
 
-The commands _getPowerStatus_, _getSWUpdateInfo_ and _getVolumeInfo_ can be extended with a suffix in the form `command:suffix`. The suffix is only relevant when using the auto filter in order to tell the filter what to filter for. The following suffixes are supported:
+The command _setVolume_ supports a simple alternative to specify the target volume by providing the volume in form of a payload of type 'number'. Use the command suffix (see below) in this case to tell the node if the volume is absolute or relative.
+
+The commands _getPowerStatus_, _getSWUpdateInfo_, _getVolumeInfo_ and _setVolume_ can be extended with a suffix in the form `command:suffix`. The suffix is only relevant when specifying the volume as payload of type 'number' or when using the auto filter in order to tell the filter what to filter for. The following suffixes are supported:
 
 |Command        |Suffix         |Description                               |
 |---------------|---------------|------------------------------------------|
@@ -181,6 +183,8 @@ The commands _getPowerStatus_, _getSWUpdateInfo_ and _getVolumeInfo_ can be exte
 |getVolumeInfo  |absolute       |Filter for absolute volume                |
 |getVolumeInfo  |relative       |Filter for relative volume                |
 |getVolumeInfo  |muted          |Filter for mute status                    |
+|setVolume      |absolute       |Payload contains absolute volume          |
+|setVolume      |relative       |Payload contains relative volume          |
 
 For more details to the input message attributes, please also check the [Filters](#filters-2) chapter further down.
 

--- a/libs/sony-event-constants.js
+++ b/libs/sony-event-constants.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+function define(name, value)
+{
+    Object.defineProperty(exports, name,
+    {
+        value: value,
+        enumerable: true
+    });
+}
+
+define("EVENT_SYSTEM_NOTIFY_POWER_STATUS",  0x01);
+define("EVENT_SYSTEM_NOTIFY_STORAGE_STATUS",  0x02);
+define("EVENT_SYSTEM_NOTIFY_SETTINGS_UPDATE", 0x04);
+define("EVENT_SYSTEM_NOTIFY_SWUPDATE_INFO",   0x08);
+
+define("EVENT_AUDIO_NOTIFY_VOLUME_INFO", 0x01);
+
+define("EVENT_AVCONTENT_NOTIFY_EXT_TERM_STATUS",      0x01);
+define("EVENT_AVCONTENT_NOTIFY_AVAIL_PB_FUNCTION",    0x02);
+define("EVENT_AVCONTENT_NOTIFY_PLAYING_CONTENT_INFO", 0x04);

--- a/libs/sony-event-recv.js
+++ b/libs/sony-event-recv.js
@@ -104,12 +104,12 @@ function EventReceiver(service, node)
                                                                                   (disable.length == 0) ? null : disable,
                                                                                   (enable.length == 0) ? null : enable));
 
-                        this.node.debug(subscribeRequest);
+                        // this.node.debug(subscribeRequest);
                         connection.sendUTF(subscribeRequest);
                     }
                     else if (msg.id == MSG_SET_NOTIFICATIONS)
                     {
-                        this.node.debug("Result: " + JSON.stringify(msg.result[0]));
+                        // this.node.debug("Result: " + JSON.stringify(msg.result[0]));
 
                         if (this.statusListener != null)
                         {
@@ -217,7 +217,7 @@ EventReceiver.prototype.connect = function(mask, callback)
         this.node.debug("Connecting to: " + this.url);
         this.client.connect(this.url);
     }
-}
+};
 
 EventReceiver.prototype.disconnect = function()
 {
@@ -228,7 +228,7 @@ EventReceiver.prototype.disconnect = function()
 
         this.connection = null;
     }
-}
+};
 
 EventReceiver.prototype.updateEventMask = function(mask)
 {
@@ -239,12 +239,12 @@ EventReceiver.prototype.updateEventMask = function(mask)
     {
         this.connection.sendUTF(JSON.stringify(switchNotifications(MSG_GET_NOTIFICATIONS, [], [])));
     }
-}
+};
 
 EventReceiver.prototype.registerStatusListener = function(listener)
 {
     this.statusListener = listener;
-}
+};
 
 function switchNotifications(id, disable, enable)
 {

--- a/libs/sony-event-recv.js
+++ b/libs/sony-event-recv.js
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2020 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const MSG_GET_NOTIFICATIONS = 1;
+const MSG_SET_NOTIFICATIONS = 2;
+
+const RECOVERY_DELAY  = 5000;
+const MAX_NUM_RETRIES = 5;
+
+const STATUS_NOTCONNECTED = {fill: "grey",  shape: "dot", text: "not connected"   };
+const STATUS_CONNECTED    = {fill: "blue",  shape: "dot", text: "connected"       };
+const STATUS_READY        = {fill: "green", shape: "dot", text: "ready"           };
+const STATUS_ERROR        = {fill: "red",   shape: "dot", text: "connection error"};
+
+const Events = require("../libs/sony-event-constants.js");
+
+const MAP_NOTIFICATIONS = {notifyPowerStatus:               Events.EVENT_SYSTEM_NOTIFY_POWER_STATUS,
+                           notifyStorageStatus:             Events.EVENT_SYSTEM_NOTIFY_STORAGE_STATUS,
+                           notifySettingsUpdate:            Events.EVENT_SYSTEM_NOTIFY_SETTINGS_UPDATE,
+                           notifySWUpdateInfo:              Events.EVENT_SYSTEM_NOTIFY_SWUPDATE_INFO,
+                           notifyVolumeInformation:         Events.EVENT_AUDIO_NOTIFY_VOLUME_INFO,
+                           notifyExternalTerminalStatus:    Events.EVENT_AVCONTENT_NOTIFY_EXT_TERM_STATUS,
+                           notifyAvailablePlaybackFunction: Events.EVENT_AVCONTENT_NOTIFY_AVAIL_PB_FUNCTION,
+                           notifyPlayingContentInfo:        Events.EVENT_AVCONTENT_NOTIFY_PLAYING_CONTENT_INFO};
+
+const WebSocketClient = require("websocket").client;
+
+
+function EventReceiver(service, node)
+{
+    this.client = new WebSocketClient();
+    this.node = node;
+
+    this.service = service;
+    this.url = "ws://" + this.node.host + ":" + this.node.port + "/sony/" + this.service;
+
+    this.eventMask = 0;
+    this.eventCallback = null;
+
+    this.statusListener = null;
+
+    this.recoverOnClose = false;
+    this.retryCount = MAX_NUM_RETRIES;
+
+    this.client.on("connect", connection =>
+    {
+        this.connection = connection;
+
+        this.node.debug("Connected to service '" + this.service + "'");
+        if (this.statusListener != null)
+        {
+            this.statusListener(STATUS_CONNECTED);
+        }
+
+        connection.on("message", message =>
+        {
+            if (message.type === "utf8")
+            {
+                let msg = JSON.parse(message.utf8Data);
+
+                if ("id" in msg)
+                {
+                    if (msg.id == MSG_GET_NOTIFICATIONS)
+                    {
+                        let notif = msg.result[0].disabled.concat(msg.result[0].enabled);
+                        let enable = [];
+                        let disable = [];
+
+                        this.node.debug("Creating method list for service '" + this.service + "' with event mask b:" + this.eventMask.toString(2).padStart(4, "0"));
+                        notif.forEach(item =>
+                        {
+                            if ((item.name in MAP_NOTIFICATIONS) && ((MAP_NOTIFICATIONS[item.name] & this.eventMask) != 0))
+                            {
+                                enable.push(item);
+                            }
+                            else
+                            {
+                                disable.push(item);
+                            }
+                        });
+
+                        let subscribeRequest = JSON.stringify(switchNotifications(MSG_SET_NOTIFICATIONS,
+                                                                                  (disable.length == 0) ? null : disable,
+                                                                                  (enable.length == 0) ? null : enable));
+
+                        this.node.debug(subscribeRequest);
+                        connection.sendUTF(subscribeRequest);
+                    }
+                    else if (msg.id == MSG_SET_NOTIFICATIONS)
+                    {
+                        this.node.debug("Result: " + JSON.stringify(msg.result[0]));
+
+                        if (this.statusListener != null)
+                        {
+                            this.statusListener(STATUS_READY);
+                        }
+                    }
+                }
+                else if (("method" in msg) && ("params" in msg))
+                {
+                    if (msg.method in MAP_NOTIFICATIONS)
+                    {
+                        this.node.debug("Event for '" + msg.method + "' received");
+
+                        let eventMsg = {service: this.service,
+                                        method: msg.method,
+                                        version: msg.version,
+                                        payload: (msg.params.length == 0) ? null : msg.params[0]};
+
+                        this.eventCallback(MAP_NOTIFICATIONS[msg.method], eventMsg);
+                    }
+                    else
+                    {
+                        this.node.warn("Unsupported event: " + msg.method);
+                    }
+                }
+                else
+                {
+                    this.node.warn("Unexpected message received");
+                }
+            }
+            else
+            {
+                this.node.warn("Unknown message type: " + message.type);
+            }
+        });
+
+        connection.on("error", error =>
+        {
+            this.node.error("Connection error: " + error.toString());
+
+            if (this.statusListener != null)
+            {
+                this.statusListener(STATUS_ERROR);
+            }
+
+            this.recoverOnClose = true;
+        });
+
+        connection.on("close", (reasonCode, description) =>
+        {
+            this.connection = null;
+
+            this.node.debug("Connection closed: " + reasonCode + " (" + description + ")");
+            if (this.statusListener != null)
+            {
+                this.statusListener(STATUS_NOTCONNECTED);
+            }
+
+            if (this.recoverOnClose && (this.retryCount > 0))
+            {
+                this.recoverOnClose = false;
+
+                setTimeout(() =>
+                {
+                    this.node.debug("Trying to recover");
+
+                    this.retryCount--;
+                    this.client.connect(this.url);
+                }, RECOVERY_DELAY);
+            }
+        });
+
+        connection.sendUTF(JSON.stringify(switchNotifications(MSG_GET_NOTIFICATIONS, [], [])));
+    });
+
+    this.client.on("connectFailed", function(error)
+    {
+        this.node.error("Connection failed: " + error.toString());
+        if (this.statusListener != null)
+        {
+            this.statusListener(STATUS_ERROR);
+        }
+
+        if (this.retryCount > 0)
+        {
+            setTimeout(() =>
+            {
+                this.node.debug("Trying to recover");
+
+                this.retryCount--;
+                this.client.connect(this.url);
+            }, RECOVERY_DELAY);
+        }
+    });
+}
+
+EventReceiver.prototype.connect = function(mask, callback)
+{
+    if (!this.connection)
+    {
+        this.eventMask = mask;
+        this.eventCallback = callback;
+        this.retryCount = MAX_NUM_RETRIES;
+
+        this.node.debug("Connecting to: " + this.url);
+        this.client.connect(this.url);
+    }
+}
+
+EventReceiver.prototype.disconnect = function()
+{
+    if (this.connection)
+    {
+        this.node.debug("Disconnecting");
+        this.connection.close();
+
+        this.connection = null;
+    }
+}
+
+EventReceiver.prototype.updateEventMask = function(mask)
+{
+    this.node.debug("Updating event mask");
+
+    this.eventMask = mask;
+    if (this.connection)
+    {
+        this.connection.sendUTF(JSON.stringify(switchNotifications(MSG_GET_NOTIFICATIONS, [], [])));
+    }
+}
+
+EventReceiver.prototype.registerStatusListener = function(listener)
+{
+    this.statusListener = listener;
+}
+
+function switchNotifications(id, disable, enable)
+{
+    var params = {};
+
+    if (disable != null)
+    {
+        params.disabled = disable;
+    }
+
+    if (enable != null)
+    {
+        params.enabled = enable;
+    }
+
+    return {id: id,
+            method: "switchNotifications",
+            version: "1.0",
+            params: [params]}
+}
+
+module.exports = EventReceiver;

--- a/nodes/sony-audio-controller.js
+++ b/nodes/sony-audio-controller.js
@@ -580,15 +580,28 @@ module.exports = function(RED)
                                 {
                                     args.zone = msg.payload.zone;
                                 }
+                            }
+                            else if (typeof msg.payload == "number")
+                            {
+                                args.volume = msg.payload;
 
-                                if ((args.relativeVolume && (args.volume == 0)) ||
-                                    (!args.relativeVolume && (args.volume < 0)))
+                                if (context.suffix === "absolute")
                                 {
-                                    setStatus(STATUS_ERROR, STATUS_TEMP_DURATION);
-                                    context.error("Invalid " + (args.relativeVolume ? "relative" : "absolute") + " volume: " + args.volume);
-
-                                    break;
+                                    args.relativeVolume = false;
                                 }
+                                else if (context.suffix === "relative")
+                                {
+                                    args.relativeVolume = true;
+                                }
+                            }
+
+                            if ((args.relativeVolume && (args.volume == 0)) ||
+                                (!args.relativeVolume && (args.volume < 0)))
+                            {
+                                setStatus(STATUS_ERROR, STATUS_TEMP_DURATION);
+                                context.error("Invalid " + (args.relativeVolume ? "relative" : "absolute") + " volume: " + args.volume);
+
+                                break;
                             }
 
                             setAudioVolume(context, args.volume, args.relativeVolume, args.zone);

--- a/nodes/sony-audio-device.html
+++ b/nodes/sony-audio-device.html
@@ -68,7 +68,7 @@ SOFTWARE.
 
                     data.forEach(device =>
                     {
-                        $("#node-config-input-devices").append($("<option></option>").val(JSON.stringify(device.address)).text(device.name));
+                        $("#node-config-input-devices").append($("<option></option>").val(JSON.stringify(device.address)).text(device.name + " [" + device.model + "]"));
                     });
 
                     if (msearch)

--- a/nodes/sony-audio-device.js
+++ b/nodes/sony-audio-device.js
@@ -69,13 +69,21 @@ module.exports = function(RED)
             {
                 let desc = xmlConverter.xml2js(response, {compact: true});
                 let devName = desc.root.device.friendlyName._text;
-                let devURL = desc.root.device["av:X_ScalarWebAPI_DeviceInfo"]["av:X_ScalarWebAPI_BaseURL"]._text;
 
-                let matches = devURL.match(URI_REGEX);
-                if (matches !== null)
+                if (desc.root.device.hasOwnProperty("av:X_ScalarWebAPI_DeviceInfo"))
                 {
-                    RED.log.debug("Found Sony audio device: " + devName + "@" + matches[1] + ":" + matches[2]);
-                    deviceList.push({name: devName, address: {host: matches[1], port: matches[2]}});
+                    let devURL = desc.root.device["av:X_ScalarWebAPI_DeviceInfo"]["av:X_ScalarWebAPI_BaseURL"]._text;
+
+                    let matches = devURL.match(URI_REGEX);
+                    if (matches !== null)
+                    {
+                        RED.log.debug("Found Sony audio device: " + devName + "@" + matches[1] + ":" + matches[2]);
+                        deviceList.push({name: devName, address: {host: matches[1], port: matches[2]}});
+                    }
+                }
+                else
+                {
+                    RED.log.debug("Ignoring device with malformed descriptor");
                 }
             }).catch(error =>
             {

--- a/nodes/sony-audio-device.js
+++ b/nodes/sony-audio-device.js
@@ -69,6 +69,7 @@ module.exports = function(RED)
             {
                 let desc = xmlConverter.xml2js(response, {compact: true});
                 let devName = desc.root.device.friendlyName._text;
+                let modelName = desc.root.device.modelName._text;
 
                 if (desc.root.device.hasOwnProperty("av:X_ScalarWebAPI_DeviceInfo"))
                 {
@@ -77,8 +78,8 @@ module.exports = function(RED)
                     let matches = devURL.match(URI_REGEX);
                     if (matches !== null)
                     {
-                        RED.log.debug("Found Sony audio device: " + devName + "@" + matches[1] + ":" + matches[2]);
-                        deviceList.push({name: devName, address: {host: matches[1], port: matches[2]}});
+                        RED.log.debug("Found Sony audio device: " + modelName + "/" + devName + "@" + matches[1] + ":" + matches[2]);
+                        deviceList.push({name: devName, model: modelName, address: {host: matches[1], port: matches[2]}});
                     }
                 }
                 else

--- a/nodes/sony-audio-receiver.js
+++ b/nodes/sony-audio-receiver.js
@@ -175,14 +175,14 @@ module.exports = function(RED)
             });
 
             node.status(STATUS_CONNECTING);
-            node.subscribeId = node.device.subscribe(config.service, filter, msg =>
+            node.subscribeId = node.device.subscribeEvents(config.service, filter, msg =>
             {
                 sendEvent(msg);
             });
 
             node.on("close", () =>
             {
-                node.device.unsubscribe(node.subscribeId);
+                node.device.unsubscribeEvents(node.subscribeId);
             });
         }
         else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-sony-audio",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Node-RED nodes for accessing Sony Audio Control API",
     "author": {
         "name": "Jens-Uwe Rossbach",


### PR DESCRIPTION
- Device discovery now also provides model name of each found device.
- Added the possibility to provide the volume for setVolume command as payload of type 'number'.
- Direct access to Sony audio control web API now abstracted by device node.
- Manage connections to Sony audio notification API centrally from device node instead of each receiver node.
- Fixed error logs during device discovery for non-conform devices using Sony's SSDP search scheme.