### PR TITLE
Improved output format for speaker settings filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2021-03-14
+### Changed
+- Changed output format for speaker settings filter in case of multiple results: instead of a value array, payload is now an object with properties for each result.
+
 ## [1.7.0] - 2021-03-13
 ### Added
 - Added support for speaker settings (**NOTE**: experimental feature, uses undocumented API, not tested!).

--- a/nodes/common/api_filter.js
+++ b/nodes/common/api_filter.js
@@ -260,7 +260,7 @@ module.exports =
             {
                 if (data.method == "getSpeakerSettings")
                 {
-                    let out = [];
+                    let out = {};
                     for (let j=0; j<data.payload.length; ++j)
                     {
                         let payload = data.payload[j];
@@ -268,38 +268,23 @@ module.exports =
                         if (("target" in payload) &&
                             ("currentValue" in payload))
                         {
-                            switch (payload.target)
+                            if (payload.type === "doubleNumberTarget")
                             {
-                                case "inCeilingSpeakerMode":
-                                case "speakerSelection":
-                                {
-                                    out.push(payload.currentValue);
-                                    break;
-                                }
-                                case "frontLLevel":
-                                case "frontRLevel":
-                                case "centerLevel":
-                                case "surroundLLevel":
-                                case "surroundRLevel":
-                                case "surroundcBackLevel":
-                                case "surroundBackLLevel":
-                                case "surroundBackRLevel":
-                                case "heightLLevel":
-                                case "heightRLevel":
-                                case "subwooferLevel":
-                                {
-                                    out.push(parseFloat(payload.currentValue));
-                                    break;
-                                }
+                                out[payload.target] = parseFloat(payload.currentValue);
+                            }
+                            else
+                            {
+                                out[payload.target] = payload.currentValue;
                             }
                         }
                     }
 
-                    if (out.length == 1)
+                    let keys = Object.keys(out);
+                    if (keys.length == 1)
                     {
-                        outputMsg = {payload: out[0]};
+                        outputMsg = {payload: out[keys[0]]};
                     }
-                    else if (out.length > 1)
+                    else if (keys.length > 1)
                     {
                         outputMsg = {payload: out};
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-sony-audio",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Node-RED nodes for accessing Sony Audio Control API",
     "author": {
         "name": "Jens-Uwe Rossbach",


### PR DESCRIPTION
Changed output format for speaker settings filter in case of multiple results: instead of a value array, payload is now an object with properties for each result.