### PR TITLE
Improved connection handling

### DIFF
--- a/nodes/controller.js
+++ b/nodes/controller.js
@@ -160,6 +160,8 @@ module.exports = function(RED)
                         case "reconnect":
                         {
                             node.device.reconnect();
+                            setStatus(STATUS_SUCCESS, STATUS_TEMP_DURATION);
+
                             break;
                         }
                         case "setVolume":


### PR DESCRIPTION
Connection handling has been improved:

1. Reconnect command of controller node now first disconnects from remote peer in case a connection seems to be still established and then starts a reconnection.
2. While being connected to the device, a ping message is sent to the websocket in a regular interval. If the ping message is not acknowledged within five seconds, the connection will be closed and the recovery mechanism starts.

Additionally the controller node now shows a green status after triggering reconnection. This is not an actual indication that the reconnection succeeded, rather it only indicates a reaction of the controller node on the trigger.